### PR TITLE
Default 'rt' mode parse mp4 fail when meet 0x0a in windows platform

### DIFF
--- a/mp4file.py
+++ b/mp4file.py
@@ -10,7 +10,7 @@ import os
 
 class Mp4File(list):
     def __init__(self, file):
-        fh = open(file)
+        fh = open(file, 'rb')
         size = os.stat(file).st_size
         while fh.tell() < size:
             root_atom = Atom( stream=fh, offset=fh.tell() )


### PR DESCRIPTION
the default open mode is 'rt', which can cause problem when meet 0x0a data in windows platform. change open mode to 'rb'
