### PR TITLE
Fix issue with mdat having size zero and readme link.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ Use cases
 Reference
 ---------
 
-- [ISO 14496-1 Media Format layout](http://www.geocities.com/xhelmboyx/quicktime/formats/mp4-layout.txt)
+- [ISO 14496-1 Media Format layout](http://xhelmboyx.tripod.com/formats/mp4-layout.txt)
 
 
 Future plans

--- a/atom.py
+++ b/atom.py
@@ -105,14 +105,17 @@ def parse_atom_header(stream, offset=0):
         header_size = large_header
     else:
         header_size = basic_header
+
+    if 0 == atom_size:
+        stream.seek(0, os.SEEK_END)
+    else:
+        # Remove the header from the size we use
+        atom_size -= header_size
     
-    # Remove the header from the size we use
-    atom_size -= header_size
-    
-    # Jump back to the end of the actual header because we will have overrun into
-    # the content, if we have a basic header)
-    offset_fix = -(len(atom_header) - header_size)
-    stream.seek(offset_fix, os.SEEK_CUR)
+        # Jump back to the end of the actual header because we will have overrun into
+        # the content, if we have a basic header)
+        offset_fix = -(len(atom_header) - header_size)
+        stream.seek(offset_fix, os.SEEK_CUR)
     
     return (atom_type, atom_size)
 


### PR DESCRIPTION
Commit 31de92a fixes an infinite loop if the mdat's size is 0, which is valid. It means the mdat extends to the end of the ifle. 

Commit 6ac3dc fixes the link in the readme, pointing it to a valid url. 